### PR TITLE
Update travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 before_install: cd Source\ Code/jspmyadmin/
 script: "mvn clean compile package"
 jdk:
-  - 7-jdk
+  - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 before_install: cd Source\ Code/jspmyadmin/
 script: "mvn clean compile package"
 jdk:
-  - oraclejdk7
+  - 7-jdk-alphine

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 before_install: cd Source\ Code/jspmyadmin/
 script: "mvn clean compile package"
 jdk:
-  - 7-jdk-alphine
+  - 7-jdk


### PR DESCRIPTION
As per oraclejdk7 updates will be deprecated from December 2016. Time to update this jdk to OpenJDK.

Image reference: https://hub.docker.com/_/openjdk/